### PR TITLE
Fix upside down screen orientation

### DIFF
--- a/networksurvey/src/main/AndroidManifest.xml
+++ b/networksurvey/src/main/AndroidManifest.xml
@@ -60,7 +60,6 @@
         <activity
             android:name=".NetworkSurveyActivity"
             android:launchMode="singleTask"
-            android:screenOrientation="fullSensor"
             android:theme="@style/NetworkSurveyTheme"
             android:windowSoftInputMode="adjustPan"
             android:exported="true">


### PR DESCRIPTION
On my phone, the app would ignore whether I had locked the screen rotation or not. I've found that this issue was caused by setting `android:screenOrientation="fullSensor"` in the Android manifest - [docs](https://developer.android.com/guide/topics/manifest/activity-element#screen)

GPSTest and GPSLogger don't set this in their manifests, so I've removed it instead of setting it to a different value.

I've tested this on real hardware.