### PR TITLE
Update Permissions for gRPC Foreground Service

### DIFF
--- a/networksurvey/src/main/AndroidManifest.xml
+++ b/networksurvey/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" /> <!-- Needed to start the service at boot -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
 
     <uses-feature
         android:name="android.hardware.location.gps"
@@ -79,7 +80,8 @@
         <service
             android:name=".services.GrpcConnectionService"
             android:description="@string/connection_service_description"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="remoteMessaging" />
 
         <meta-data
             android:name="android.content.APP_RESTRICTIONS"

--- a/networksurvey/src/main/java/com/craxiom/networksurvey/services/GrpcConnectionService.java
+++ b/networksurvey/src/main/java/com/craxiom/networksurvey/services/GrpcConnectionService.java
@@ -11,10 +11,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
+import android.content.pm.ServiceInfo;
 import android.location.Location;
 import android.os.AsyncTask;
 import android.os.BatteryManager;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
@@ -805,7 +807,12 @@ public class GrpcConnectionService extends Service implements IDeviceStatusListe
                 .setTicker(getText(R.string.connection_notification_title))
                 .build();
 
-        startForeground(NetworkSurveyConstants.GRPC_CONNECTION_NOTIFICATION_ID, notification);
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU) {
+            startForeground(NetworkSurveyConstants.GRPC_CONNECTION_NOTIFICATION_ID, notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING);
+        } else {
+            startForeground(NetworkSurveyConstants.GRPC_CONNECTION_NOTIFICATION_ID, notification);
+        }
     }
 
     /**


### PR DESCRIPTION
Ensure a permission is provided for starting a foreground service when doing so for the gRPC service. Android 14 (sdk 34) requires specifying the foreground permission specifically needed by the service. In this case, remote messaging fits.